### PR TITLE
allow oauth assets

### DIFF
--- a/infra/constructs/compute.ts
+++ b/infra/constructs/compute.ts
@@ -114,6 +114,7 @@ export class Compute extends Construct {
           '/xrpc/*',
           '/.well-known/*',
           '/oauth/*',
+          '/@atproto/oauth-provider/*',
           '/tls-check',
         ]),
       ],


### PR DESCRIPTION
The oauth assets (js / css) can't be loaded from the PDS without this setting.

*Description of changes:*

Add load balancer listener rule to allow assets being loaded from PDS.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
